### PR TITLE
Update for MS DI adapter to return null on missing registration

### DIFF
--- a/src/stashbox.extensions.dependencyinjection/StashboxServiceProvider.cs
+++ b/src/stashbox.extensions.dependencyinjection/StashboxServiceProvider.cs
@@ -53,8 +53,26 @@ public sealed class StashboxServiceProvider : IServiceProvider, ISupportRequired
 
 #if HAS_KEYED
     /// <inheritdoc />
-    public object? GetKeyedService(Type serviceType, object? serviceKey) =>
-        this.dependencyResolver.ResolveOrDefault(serviceType, serviceKey);
+    public object? GetKeyedService(Type serviceType, object? serviceKey)
+    {
+        // MSDI contract: passing KeyedService.AnyKey to a single-service getter is ambiguous.
+        // Matches Microsoft.Extensions.DependencyInjection.ServiceProvider.GetKeyedService.
+        if (KeyedService.AnyKey.Equals(serviceKey))
+            throw new InvalidOperationException(
+                "This service descriptor is keyed. Your service provider may not support keyed services.");
+
+        // MSDI contract: return null when no registration matches the (type, key) pair.
+        // The container is configured with WithForceThrowWhenNamedDependencyIsNotResolvable
+        // so that [FromKeyedServices] constructor injection fails loudly, but that flag also
+        // makes a plain ResolveOrDefault(type, name) throw on miss. Gate the call on CanResolve
+        // so a confirmed miss returns null without invoking the throwing path, while anything
+        // that could resolve (including the AnyKey/universal-name fallback) still goes through
+        // ResolveOrDefault — genuine activation failures propagate as before.
+        return this.dependencyResolver.CanResolve(serviceType, serviceKey)
+               || this.dependencyResolver.CanResolve(serviceType, KeyedService.AnyKey)
+            ? this.dependencyResolver.ResolveOrDefault(serviceType, serviceKey)
+            : null;
+    }
 
     /// <inheritdoc />
     public object GetRequiredKeyedService(Type serviceType, object? serviceKey) =>

--- a/test/stashbox.extensions.dependencyinjection.tests/ServiceProviderTests.cs
+++ b/test/stashbox.extensions.dependencyinjection.tests/ServiceProviderTests.cs
@@ -105,18 +105,71 @@ public class ServiceProviderTests
         Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService(typeof(Service1)));
         Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<Service1>());
     }
-#if HAS_KEYED    
+#if HAS_KEYED
     [Fact]
     public void Keyed_Tests()
     {
         var services = new ServiceCollection();
-        
+
         services.AddKeyedTransient(typeof(IService), "A", typeof(Service1));
         services.AddTransient(typeof(IService), typeof(Service2));
 
         var serviceProvider = services.UseStashbox();
-        
+
         Assert.IsType<Service1>(serviceProvider.GetRequiredKeyedService(typeof(IService), "A"));
+    }
+
+    [Fact]
+    public void GetKeyedService_ReturnsNull_WhenKeyMissing_ForRegisteredType()
+    {
+        // MSDI contract: GetKeyedService must return null when no registration matches the
+        // (type, key) pair, even if the type is registered under a different (or no) key.
+        var services = new ServiceCollection();
+        services.AddTransient<IService, Service1>();
+        var serviceProvider = services.UseStashbox();
+        var keyed = (IKeyedServiceProvider)serviceProvider;
+
+        Assert.Null(serviceProvider.GetKeyedService<IService>("missing-key"));
+        Assert.Null(keyed.GetKeyedService(typeof(IService), "missing-key"));
+    }
+
+    [Fact]
+    public void GetKeyedService_ReturnsNull_WhenTypeUnregistered()
+    {
+        var services = new ServiceCollection();
+        var serviceProvider = services.UseStashbox();
+        var keyed = (IKeyedServiceProvider)serviceProvider;
+
+        Assert.Null(serviceProvider.GetKeyedService<IService>("any-key"));
+        Assert.Null(keyed.GetKeyedService(typeof(IService), "any-key"));
+    }
+
+    [Fact]
+    public void GetKeyedService_ReturnsNull_WhenKeyIsTypeObject_AndUnregistered()
+    {
+        // Reproduces the HybridCache scenario: DefaultJsonSerializerFactory calls
+        // sp.GetKeyedService<JsonSerializerOptions>(typeof(IHybridCacheSerializer<>))
+        // expecting null when nothing is registered under that Type-valued key.
+        var services = new ServiceCollection();
+        services.AddTransient<IService, Service1>();
+        var serviceProvider = services.UseStashbox();
+        var keyed = (IKeyedServiceProvider)serviceProvider;
+
+        Assert.Null(serviceProvider.GetKeyedService<IService>(typeof(IDisposable)));
+        Assert.Null(keyed.GetKeyedService(typeof(IService), typeof(IDisposable)));
+    }
+
+    [Fact]
+    public void GetRequiredKeyedService_StillThrows_WhenKeyMissing()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IService, Service1>();
+        var serviceProvider = services.UseStashbox();
+
+        Assert.Throws<InvalidOperationException>(
+            () => serviceProvider.GetRequiredKeyedService<IService>("missing-key"));
+        Assert.Throws<InvalidOperationException>(
+            () => serviceProvider.GetRequiredKeyedService(typeof(IService), "missing-key"));
     }
 #endif
     


### PR DESCRIPTION
Created issue here:

https://github.com/z4kn4fein/stashbox/issues/230

But found the code that could fix it in this PR